### PR TITLE
sepolicy: sdcard_posix_contextmount_type,

### DIFF
--- a/common/private/file.te
+++ b/common/private/file.te
@@ -1,4 +1,4 @@
-type sdcard_posix, sdcard_type, fs_type, mlstrustedobject;
+type sdcard_posix, sdcard_type, sdcard_posix_contextmount_type, fs_type, mlstrustedobject;
 type sysfs_io_sched_tuneable, fs_type, sysfs_type;
 type adbroot_data_file, file_type, data_file_type, core_data_file_type;
 type pocket_judge_sysfs, fs_type, sysfs_type;


### PR DESCRIPTION
overcoming neverallows and other -user build shenanigans